### PR TITLE
Apply deletion filters when retrieving data

### DIFF
--- a/lib/sequel/plugins/soft_destroy.rb
+++ b/lib/sequel/plugins/soft_destroy.rb
@@ -9,7 +9,13 @@ module Sequel
         Sequel::Plugins.def_dataset_methods(self, :filter_deleted)
 
         def [](*args)
-          model = super
+          args = args.first if args.size <= 1
+
+          return filter_deleted.first(args) if args.is_a?(Hash)
+
+          return if args.nil?
+
+          model = primary_key_lookup(args)
 
           return if model.nil? || model.deleted?
 

--- a/test/sequel/plugins/soft_destroy_test.rb
+++ b/test/sequel/plugins/soft_destroy_test.rb
@@ -48,9 +48,19 @@ class SoftDestroyTest < Minitest::Test
     assert_equal [foo_1, foo_2], Foo.filter_deleted.where(Sequel.ilike(:name, "foo%")).all
   end
 
-  def test_fetch
+  def test_fetch_by_id
     foo = Foo.create(name: "foo 1").soft_destroy
 
     assert_nil Foo[foo.id]
+  end
+
+  def test_fetch_by_key
+    foo_1 = Foo.create(name: "foo").soft_destroy
+
+    assert_nil Foo[name: "foo"]
+
+    foo_2 = Foo.create(name: "foo")
+
+    assert_equal foo_2, Foo[name: "foo"]
   end
 end


### PR DESCRIPTION
This PR improves the retrieve method `Model#[]` to be able to fetch the first non-deleted record in case there is more than one record and not all of them were soft-destroyed.